### PR TITLE
feat: add live feed of latest numbers

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,15 +7,17 @@ app = Flask(__name__)
 
 # Global counters + lock
 even_count, odd_count = 0, 0
+latest_number = 0
 streaming = True
 
 def number_stream():
-    global even_count, odd_count, streaming
+    global even_count, odd_count, streaming, latest_number
     while True:
         if streaming:
             num = random.randint(1, 100)
             if num % 2 == 0:
                 even_count += 1
+                latest_number = {"number": num, "type": "even"}
                 try:
                     with open("evens.txt", "a") as f:
                         f.write(str(num) + "\n")
@@ -24,6 +26,7 @@ def number_stream():
                 print(f"{num} → Even")
             else:
                 odd_count += 1
+                latest_number = {"number": num, "type": "odd"}
                 try:
                     with open("odds.txt", "a") as f:
                         f.write(str(num) + "\n")
@@ -39,7 +42,7 @@ def index():
 
 @app.route("/data")
 def get_data():
-    return jsonify({"even": even_count, "odd": odd_count})
+    return jsonify({"even": even_count, "odd": odd_count, "latest": latest_number})
 
 @app.route("/start")
 def start():

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,11 @@
   <title>Odd/Even Dashboard</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
-    body { font-family: Arial, sans-serif; text-align: center; background: #f2f2f2; }
+    body {
+      font-family: Arial, sans-serif;
+      text-align: center;
+      background: #f2f2f2;
+    }
     h1 { color: #333; }
     .chart-container {
       display: flex;
@@ -32,6 +36,35 @@
       font-size: 14px;
       cursor: pointer;
     }
+
+    /* 📜 Feed panel styles */
+    #feed-container {
+      margin: 30px auto; 
+      width: 400px; 
+      background: white; 
+      padding: 10px; 
+      border-radius: 8px; 
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      text-align: left;
+    }
+    #feed-container h2 {
+      margin-top: 0;
+      font-size: 18px;
+      border-bottom: 1px solid #eee;
+      padding-bottom: 5px;
+    }
+    #feed {
+      list-style: none;
+      padding-left: 0;
+      max-height: 200px;
+      overflow-y: auto;
+      font-family: monospace;
+      margin: 0;
+    }
+    #feed li {
+      padding: 4px;
+      border-bottom: 1px solid #eee;
+    }
   </style>
 </head>
 <body>
@@ -48,9 +81,16 @@
     </div>
   </div>
 
+  <!-- 📜 Live feed panel -->
+  <div id="feed-container">
+    <h2>📜 Latest Numbers</h2>
+    <ul id="feed"></ul>
+  </div>
+
   <script>
     const lineCtx = document.getElementById("lineChart").getContext("2d");
     const pieCtx = document.getElementById("pieChart").getContext("2d");
+    const feed = document.getElementById("feed");
 
     const lineChart = new Chart(lineCtx, {
       type: "line",
@@ -118,14 +158,36 @@
         step++;
 
         // Update line chart
+        const MAX_POINTS = 50;
+
+
         lineChart.data.labels.push(step);
         lineChart.data.datasets[0].data.push(data.even || 0);
         lineChart.data.datasets[1].data.push(data.odd || 0);
+
+        if (lineChart.data.labels.length > MAX_POINTS) {
+          lineChart.data.labels.shift();
+          lineChart.data.datasets.data.shift();
+          lineChart.data.datasets[1].data.shift();
+        }
+
         lineChart.update();
 
         // Update pie chart
         pieChart.data.datasets[0].data = [data.even || 0, data.odd || 0];
         pieChart.update();
+
+        // Update feed with latest number
+        if (data.latest) {
+          const li = document.createElement("li");
+          li.textContent = `${data.latest.number} → ${data.latest.type.toUpperCase()}`;
+          li.style.color = data.latest.type === "even" ? "blue" : "red";
+
+          feed.insertBefore(li, feed.firstChild);
+          if (feed.childElementCount > 10) { 
+            feed.removeChild(feed.lastChild);
+          }
+        }
       } catch (error) {
         console.error("Fetch error:", error);
       }


### PR DESCRIPTION
### Summary
Added a panel displaying the latest streamed numbers.

### Why
Why not?

### Changes
- Adjusted frontend to properly fetch and display the latest streamed number from backend.
- Implemented a scrolling list below charts that updates and color-codes odds and evens.

### Notes
- Updated backend to include latest number data in API response for feed synchronization.